### PR TITLE
Re add lure pokemon

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -14,7 +14,7 @@ from datetime import timedelta
 from collections import OrderedDict
 
 from . import config
-from .models import Pokemon, Gym, Pokestop, ScannedLocation
+from .models import Pokemon, LurePokemon, Gym, Pokestop, ScannedLocation
 
 log = logging.getLogger(__name__)
 compress = Compress()
@@ -86,8 +86,13 @@ class Pogom(Flask):
                 ids = [int(x) for x in request.args.get('ids').split(',')]
                 d['pokemons'] = Pokemon.get_active_by_id(ids, swLat, swLng,
                                                          neLat, neLng)
+                d['pokemons'].extend(LurePokemon.get_active_by_id(ids, swLat, swLng,
+                                                                  neLat, neLng))
+
             else:
                 d['pokemons'] = Pokemon.get_active(swLat, swLng, neLat, neLng)
+                d['pokemons'].extend(LurePokemon.get_active(swLat, swLng,
+                                                            neLat, neLng))
 
         if request.args.get('pokestops', 'true') == 'true':
             d['pokestops'] = Pokestop.get_stops(swLat, swLng, neLat, neLng)

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -86,13 +86,16 @@ class Pogom(Flask):
                 ids = [int(x) for x in request.args.get('ids').split(',')]
                 d['pokemons'] = Pokemon.get_active_by_id(ids, swLat, swLng,
                                                          neLat, neLng)
-                d['pokemons'].extend(LurePokemon.get_active_by_id(ids, swLat, swLng,
-                                                                  neLat, neLng))
-
             else:
                 d['pokemons'] = Pokemon.get_active(swLat, swLng, neLat, neLng)
-                d['pokemons'].extend(LurePokemon.get_active(swLat, swLng,
-                                                            neLat, neLng))
+
+        if request.args.get('lurePokemon', 'true') == 'true':
+            if request.args.get('ids'):
+                ids = [int(x) for x in request.args.get('ids').split(',')]
+                d['lurePokemons'] = LurePokemon.get_active_by_id(ids, swLat, swLng,
+                                                                 neLat, neLng)
+            else:
+                d['lurePokemons'] = LurePokemon.get_active(swLat, swLng, neLat, neLng)
 
         if request.args.get('pokestops', 'true') == 'true':
             d['pokestops'] = Pokestop.get_stops(swLat, swLng, neLat, neLng)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -78,7 +78,6 @@ class PokemonBaseModel(BaseModel):
     longitude = DoubleField()
     disappear_time = DateTimeField(index=True)
 
-
     @staticmethod
     def _get_active(base, swLat, swLng, neLat, neLng):
 
@@ -705,4 +704,3 @@ def database_migrate(db, old_ver):
                  .where(Pokemon.disappear_time >
                         (datetime.utcnow() - timedelta(hours=24))))
         query.execute()
-

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -69,18 +69,14 @@ class BaseModel(flaskDb.Model):
         return results
 
 
-class Pokemon(BaseModel):
+class PokemonBaseModel(BaseModel):
     # We are base64 encoding the ids delivered by the api
     # because they are too big for sqlite to handle
     encounter_id = CharField(primary_key=True, max_length=50)
-    spawnpoint_id = CharField(index=True)
     pokemon_id = IntegerField(index=True)
     latitude = DoubleField()
     longitude = DoubleField()
     disappear_time = DateTimeField(index=True)
-
-    class Meta:
-        indexes = ((('latitude', 'longitude'), False),)
 
     @staticmethod
     def get_active(swLat, swLng, neLat, neLng):
@@ -141,6 +137,13 @@ class Pokemon(BaseModel):
             pokemons.append(p)
 
         return pokemons
+
+
+class Pokemon(PokemonBaseModel):
+    spawnpoint_id = CharField(index=True)
+
+    class Meta:
+        indexes = ((('latitude', 'longitude'), False),)
 
     @classmethod
     def get_seen(cls, timediff):
@@ -262,6 +265,12 @@ class Pokemon(BaseModel):
         return trueSpawns
 
 
+class LurePokemon(PokemonBaseModel):
+    pokestop_id = CharField(index=True, max_length=50)
+
+    class Meta:
+        indexes = ((('latitude', 'longitude'), False),)
+
 class Pokestop(BaseModel):
     pokestop_id = CharField(primary_key=True, max_length=50)
     enabled = BooleanField()
@@ -377,6 +386,7 @@ class Versions(flaskDb.Model):
 # todo: this probably shouldn't _really_ be in "models" anymore, but w/e
 def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue):
     pokemons = {}
+    lure_pokemons = {}
     pokestops = {}
     gyms = {}
 
@@ -438,9 +448,9 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue):
 
                     if lure_info is not None:
                         d_t = datetime.utcfromtimestamp(lure_info['lure_expires_timestamp_ms'] / 1000)
-                        pokemons[lure_info['encounter_id']] = {
+                        lure_pokemons[lure_info['encounter_id']] = {
                             'encounter_id': b64encode(str(lure_info['encounter_id'])),
-                            'spawnpoint_id': 'lure',
+                            'pokestop_id': f['id'],
                             'pokemon_id': lure_info['active_pokemon_id'],
                             'latitude': f['latitude'] + 0.00005,
                             'longitude': f['longitude'] + 0.00005,
@@ -514,26 +524,28 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue):
         db_update_queue.put((Pokestop, pokestops))
     if len(gyms):
         db_update_queue.put((Gym, gyms))
+    if len(lure_pokemons):
+        db_update_queue.put((LurePokemon, lure_pokemons))
 
-    log.info('Parsing found %d pokemons, %d pokestops, and %d gyms',
+    log.info('Parsing found %d pokemons, %d lured pokemon, %d pokestops, and %d gyms',
              len(pokemons),
+             len(lure_pokemons),
              len(pokestops),
              len(gyms))
 
     db_update_queue.put((ScannedLocation, {0: {
+        'last_modified': calendar.timegm(gyms[f['id']]['last_modified'].timetuple()),
         'latitude': step_location[0],
         'longitude': step_location[1],
         'last_modified': datetime.utcnow()
     }}))
 
-    return len(pokemons) + len(pokestops) + len(gyms)
-
+    return len(pokemons) + len(lure_pokemons) + len(pokestops) + len(gyms)
 
 def db_updater(args, q):
     # The forever loop
     while True:
         try:
-
             while True:
                 try:
                     flaskDb.connect_db()
@@ -600,13 +612,13 @@ def bulk_upsert(cls, data):
 def create_tables(db):
     db.connect()
     verify_database_schema(db)
-    db.create_tables([Pokemon, Pokestop, Gym, ScannedLocation], safe=True)
+    db.create_tables([Pokemon, LurePokemon, Pokestop, Gym, ScannedLocation], safe=True)
     db.close()
 
 
 def drop_tables(db):
     db.connect()
-    db.drop_tables([Pokemon, Pokestop, Gym, ScannedLocation, Versions], safe=True)
+    db.drop_tables([Pokemon, LurePokemon, Pokestop, Gym, ScannedLocation, Versions], safe=True)
     db.close()
 
 
@@ -674,3 +686,4 @@ def database_migrate(db, old_ver):
                  .where(Pokemon.disappear_time >
                         (datetime.utcnow() - timedelta(hours=24))))
         query.execute()
+

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -466,14 +466,25 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue):
 
                     if lure_info is not None:
                         d_t = datetime.utcfromtimestamp(lure_info['lure_expires_timestamp_ms'] / 1000)
+                        encounter_id = b64encode(str(lure_info['encounter_id']))
                         lure_pokemons[lure_info['encounter_id']] = {
-                            'encounter_id': b64encode(str(lure_info['encounter_id'])),
+                            'encounter_id': encounter_id,
                             'pokestop_id': f['id'],
                             'pokemon_id': lure_info['active_pokemon_id'],
                             'latitude': f['latitude'] + 0.0001,
                             'longitude': f['longitude'] + 0.0001,
                             'disappear_time': d_t
                         }
+                        webhook_data = {
+                            'encounter_id': encounter_id,
+                            'pokemon_id': lure_info['active_pokemon_id'],
+                            'pokestop_id': f['id'],
+                            'latitude': f['latitude'],
+                            'longitude': f['longitude'],
+                            'disappear_time': calendar.timegm(d_t.timetuple()),
+                            'active_fort_modifier': active_fort_modifier
+                        }
+                        send_to_webhook('pokemon', webhook_data)
 
                 else:
                     lure_expiration, active_fort_modifier = None, None

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -470,8 +470,8 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue):
                             'encounter_id': b64encode(str(lure_info['encounter_id'])),
                             'pokestop_id': f['id'],
                             'pokemon_id': lure_info['active_pokemon_id'],
-                            'latitude': f['latitude'] + 0.00005,
-                            'longitude': f['longitude'] + 0.00005,
+                            'latitude': f['latitude'] + 0.0001,
+                            'longitude': f['longitude'] + 0.0001,
                             'disappear_time': d_t
                         }
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -475,16 +475,16 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue):
                             'longitude': f['longitude'] + 0.0001,
                             'disappear_time': d_t
                         }
-                        webhook_data = {
-                            'encounter_id': encounter_id,
-                            'pokemon_id': lure_info['active_pokemon_id'],
-                            'pokestop_id': f['id'],
-                            'latitude': f['latitude'],
-                            'longitude': f['longitude'],
-                            'disappear_time': calendar.timegm(d_t.timetuple()),
-                            'active_fort_modifier': active_fort_modifier
-                        }
-                        send_to_webhook('lure_pokemon', webhook_data)
+                        if args.webhooks:
+                            wh_update_queue.put(('lure_pokemon', {
+                                'encounter_id': encounter_id,
+                                'pokestop_id': f['id'],
+                                'pokemon_id': lure_info['active_pokemon_id'],
+                                'latitude': f['latitude'],
+                                'longitude': f['longitude'],
+                                'disappear_time': calendar.timegm(d_t.timetuple()),
+                                'active_fort_modifier': active_fort_modifier
+                            }))
 
                 else:
                     lure_expiration, active_fort_modifier = None, None
@@ -563,13 +563,13 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue):
              len(gyms))
 
     db_update_queue.put((ScannedLocation, {0: {
-        'last_modified': calendar.timegm(gyms[f['id']]['last_modified'].timetuple()),
         'latitude': step_location[0],
         'longitude': step_location[1],
         'last_modified': datetime.utcnow()
     }}))
 
     return len(pokemons) + len(lure_pokemons) + len(pokestops) + len(gyms)
+
 
 def db_updater(args, q):
     # The forever loop

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -78,21 +78,23 @@ class PokemonBaseModel(BaseModel):
     longitude = DoubleField()
     disappear_time = DateTimeField(index=True)
 
+
     @staticmethod
-    def get_active(swLat, swLng, neLat, neLng):
+    def _get_active(base, swLat, swLng, neLat, neLng):
+
         if swLat is None or swLng is None or neLat is None or neLng is None:
-            query = (Pokemon
+            query = (base
                      .select()
-                     .where(Pokemon.disappear_time > datetime.utcnow())
+                     .where(base.disappear_time > datetime.utcnow())
                      .dicts())
         else:
-            query = (Pokemon
+            query = (base
                      .select()
-                     .where((Pokemon.disappear_time > datetime.utcnow()) &
-                            (Pokemon.latitude >= swLat) &
-                            (Pokemon.longitude >= swLng) &
-                            (Pokemon.latitude <= neLat) &
-                            (Pokemon.longitude <= neLng))
+                     .where((base.disappear_time > datetime.utcnow()) &
+                            (base.latitude >= swLat) &
+                            (base.longitude >= swLng) &
+                            (base.latitude <= neLat) &
+                            (base.longitude <= neLng))
                      .dicts())
 
         pokemons = []
@@ -108,22 +110,22 @@ class PokemonBaseModel(BaseModel):
         return pokemons
 
     @staticmethod
-    def get_active_by_id(ids, swLat, swLng, neLat, neLng):
+    def _get_active_by_id(base, ids, swLat, swLng, neLat, neLng):
         if swLat is None or swLng is None or neLat is None or neLng is None:
-            query = (Pokemon
+            query = (base
                      .select()
-                     .where((Pokemon.pokemon_id << ids) &
-                            (Pokemon.disappear_time > datetime.utcnow()))
+                     .where((base.pokemon_id << ids) &
+                            (base.disappear_time > datetime.utcnow()))
                      .dicts())
         else:
-            query = (Pokemon
+            query = (base
                      .select()
-                     .where((Pokemon.pokemon_id << ids) &
-                            (Pokemon.disappear_time > datetime.utcnow()) &
-                            (Pokemon.latitude >= swLat) &
-                            (Pokemon.longitude >= swLng) &
-                            (Pokemon.latitude <= neLat) &
-                            (Pokemon.longitude <= neLng))
+                     .where((base.pokemon_id << ids) &
+                            (base.disappear_time > datetime.utcnow()) &
+                            (base.latitude >= swLat) &
+                            (base.longitude >= swLng) &
+                            (base.latitude <= neLat) &
+                            (base.longitude <= neLng))
                      .dicts())
 
         pokemons = []
@@ -144,6 +146,14 @@ class Pokemon(PokemonBaseModel):
 
     class Meta:
         indexes = ((('latitude', 'longitude'), False),)
+
+    @staticmethod
+    def get_active_by_id(ids, swLat, swLng, neLat, neLng):
+        return PokemonBaseModel._get_active_by_id(Pokemon, ids, swLat, swLng, neLat, neLng)
+
+    @staticmethod
+    def get_active(swLat, swLng, neLat, neLng):
+        return PokemonBaseModel._get_active(Pokemon, swLat, swLng, neLat, neLng)
 
     @classmethod
     def get_seen(cls, timediff):
@@ -270,6 +280,15 @@ class LurePokemon(PokemonBaseModel):
 
     class Meta:
         indexes = ((('latitude', 'longitude'), False),)
+
+    @staticmethod
+    def get_active_by_id(ids, swLat, swLng, neLat, neLng):
+        return PokemonBaseModel._get_active_by_id(LurePokemon, ids, swLat, swLng, neLat, neLng)
+
+    @staticmethod
+    def get_active(swLat, swLng, neLat, neLng):
+        return PokemonBaseModel._get_active(LurePokemon, swLat, swLng, neLat, neLng)
+
 
 class Pokestop(BaseModel):
     pokestop_id = CharField(primary_key=True, max_length=50)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -484,7 +484,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue):
                             'disappear_time': calendar.timegm(d_t.timetuple()),
                             'active_fort_modifier': active_fort_modifier
                         }
-                        send_to_webhook('pokemon', webhook_data)
+                        send_to_webhook('lure_pokemon', webhook_data)
 
                 else:
                     lure_expiration, active_fort_modifier = None, None

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -738,6 +738,10 @@ var StoreOptions = {
     default: true,
     type: StoreTypes.Boolean
   },
+  'showLurePokemon': {
+    default: true,
+    type: StoreTypes.Boolean
+  },
   'showPokestops': {
     default: true,
     type: StoreTypes.Boolean
@@ -980,6 +984,7 @@ function updateSearchStatus () {
 function initSidebar () {
   $('#gyms-switch').prop('checked', Store.get('showGyms'))
   $('#pokemon-switch').prop('checked', Store.get('showPokemon'))
+  $('#lure-pokemon-switch').prop('checked', Store.get('showLurePokemon'))
   $('#pokestops-switch').prop('checked', Store.get('showPokestops'))
   $('#lured-pokestops-only-switch').val(Store.get('showLuredPokestopsOnly'))
   $('#lured-pokestops-only-wrapper').toggle(Store.get('showPokestops'))
@@ -1370,7 +1375,7 @@ function clearStaleMarkers () {
   })
 
   $.each(mapData.lurePokemons, function (key, value) {
-    if (mapData.lurePokemons[key]['lure_expiration'] < new Date().getTime() ||
+    if (mapData.lurePokemons[key]['disappear_time'] < new Date().getTime() ||
       excludedPokemon.indexOf(mapData.lurePokemons[key]['pokemon_id']) >= 0) {
       mapData.lurePokemons[key].marker.setMap(null)
       delete mapData.lurePokemons[key]
@@ -1420,6 +1425,7 @@ function showInBoundsMarkers (markers) {
 
 function loadRawData () {
   var loadPokemon = Store.get('showPokemon')
+  var loadLurePokemon = Store.get('showLurePokemon')
   var loadGyms = Store.get('showGyms')
   var loadPokestops = Store.get('showPokestops')
   var loadScanned = Store.get('showScanned')
@@ -1438,6 +1444,7 @@ function loadRawData () {
     type: 'GET',
     data: {
       'pokemon': loadPokemon,
+      'lurePokemon': loadLurePokemon,
       'pokestops': loadPokestops,
       'gyms': loadGyms,
       'scanned': loadScanned,
@@ -1476,6 +1483,24 @@ function processPokemons (i, item) {
     if (!item.hidden) {
       item.marker = setupPokemonMarker(item)
       mapData.pokemons[item['encounter_id']] = item
+    }
+  }
+}
+
+function processLurePokemons (i, item) {
+  if (!Store.get('showLurePokemon')) {
+    return false // in case the checkbox was unchecked in the meantime.
+  }
+
+  if (!(item['encounter_id'] in mapData.lurePokemons) &&
+    excludedPokemon.indexOf(item['pokemon_id']) < 0) {
+    // add marker to map and item to dict
+    if (item.marker) {
+      item.marker.setMap(null)
+    }
+    if (!item.hidden) {
+      item.marker = setupPokemonMarker(item)
+      mapData.lurePokemons[item['encounter_id']] = item
     }
   }
 }
@@ -1580,11 +1605,9 @@ function processSpawnpoints (i, item) {
 function updateMap () {
   loadRawData().done(function (result) {
     var lurePokemons = {}
-    $.each(result.pokemons, function (i, item) {
-      if ('pokestop_id' in item) {
-        var pokestopId = item['pokestop_id']
-        lurePokemons[pokestopId] = item
-      }
+    $.each(result.lurePokemons, function (i, item) {
+      var pokestopId = item['pokestop_id']
+      lurePokemons[pokestopId] = item
     })
     $.each(result.pokestops, function (i, item) {
       var pokestopId = item['pokestop_id']
@@ -1594,6 +1617,7 @@ function updateMap () {
     })
 
     $.each(result.pokemons, processPokemons)
+    $.each(result.lurePokemons, processLurePokemons)
     $.each(result.pokestops, processPokestops)
     $.each(result.gyms, processGyms)
     $.each(result.scanned, processScanned)
@@ -2067,6 +2091,7 @@ $(function () {
   // Setup UI element interactions
   $('#gyms-switch').change(buildSwitchChangeListener(mapData, ['gyms'], 'showGyms'))
   $('#pokemon-switch').change(buildSwitchChangeListener(mapData, ['pokemons'], 'showPokemon'))
+  $('#lure-pokemon-switch').change(buildSwitchChangeListener(mapData, ['lurePokemons'], 'showLurePokemon'))
   $('#scanned-switch').change(buildSwitchChangeListener(mapData, ['scanned'], 'showScanned'))
   $('#spawnpoints-switch').change(buildSwitchChangeListener(mapData, ['spawnpoints'], 'showSpawnpoints'))
 

--- a/templates/map.html
+++ b/templates/map.html
@@ -50,8 +50,18 @@
               <div class="onoffswitch">
                 <input id="pokemon-switch" type="checkbox" name="pokemon-switch" class="onoffswitch-checkbox" checked>
                 <label class="onoffswitch-label" for="pokemon-switch">
-                <span class="switch-label" data-on="On" data-off="Off"></span>
-                <span class="switch-handle"></span>
+                  <span class="switch-label" data-on="On" data-off="Off"></span>
+                  <span class="switch-handle"></span>
+                </label>
+              </div>
+            </div>
+            <div class="form-control switch-container">
+              <h3>Lured Pokémon</h3>
+              <div class="onoffswitch">
+                <input id="lure-pokemon-switch" type="checkbox" name="lure-pokemon-switch" class="onoffswitch-checkbox" checked>
+                <label class="onoffswitch-label" for="lure-pokemon-switch">
+                  <span class="switch-label" data-on="On" data-off="Off"></span>
+                  <span class="switch-handle"></span>
                 </label>
               </div>
             </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The problem here is that lure_info field is only present when the scan is close enough to the pokestop this way if we store those info in the pokestop database as soon an other scan find the pokestop but is too far from the stop to get the lure_info field it will erase the lured pokemon from the database

This version use a new table to store lure info.

Most of the frontend code was already present from previous implementation
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since last api change the lured pokemon arent displayed 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
