### PR TITLE
Make POIs unclickable.

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -858,6 +858,7 @@ function initMap () { // eslint-disable-line no-unused-vars
     fullscreenControl: true,
     streetViewControl: false,
     mapTypeControl: false,
+    clickableIcons: false,
     mapTypeControlOptions: {
       style: google.maps.MapTypeControlStyle.DROPDOWN_MENU,
       position: google.maps.ControlPosition.RIGHT_TOP,

--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -267,6 +267,7 @@ function initMap () {
     fullscreenControl: false,
     streetViewControl: false,
     mapTypeControl: true,
+    clickableIcons: false,
     mapTypeControlOptions: {
       style: google.maps.MapTypeControlStyle.DROPDOWN_MENU,
       position: google.maps.ControlPosition.RIGHT_TOP,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Disables clickableIcons in MapOptions, to prevent POIs from showing an infowindow. This might have been intended behavior, but it bothered me and figure others might appreciate the change.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously, POIs would show an infowindow offering directions, etc. I would sometimes click on the POI when intending to click on a Pokémon, stop or gym. Personally, the directions and Google search offer no added value. This change keeps the POI labels, but makes them unclickable.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally, made sure other clickable items (mons, stops, gyms) remain unaffected.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

